### PR TITLE
Only madvise(2) MADV_HUGEPAGE if defined.

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -108,7 +108,7 @@ ubyte *alloc_huge(long64 size)
     fprintf(stderr, "Could not allocate sufficient memory.\n");
     exit(1);
   }
-#ifdef __linux__
+#ifdef MADV_HUGEPAGE
   madvise((void *)ptr, size, MADV_HUGEPAGE);
 #endif
 


### PR DESCRIPTION
`#ifdef __linux__` is not a sufficient condition.