### PR TITLE
Honor sizeof(T) in the addition in 16-bit case

### DIFF
--- a/src/permute_tmpl.c
+++ b/src/permute_tmpl.c
@@ -329,7 +329,7 @@ void NAME(estimate_compression_piece)(T *restrict table,
   int i, p;
 
   uint32_t dsize = num_segs * seg_size;
-  T *restrict dst = malloc(num_cands * dsize * sizeof(T) + 1);
+  T *restrict dst = malloc((num_cands * dsize + 1) * sizeof(T));
   NAME(est_data).table = table;
   NAME(est_data).pcs = pcs;
   NAME(est_data).dst = dst;
@@ -365,7 +365,7 @@ void NAME(estimate_compression_pawn)(T *restrict table, int *restrict pcs,
   int i, p;
 
   uint32_t dsize = num_segs * seg_size;
-  T *restrict dst = malloc(num_cands * dsize * sizeof(T) + 1);
+  T *restrict dst = malloc((num_cands * dsize + 1) * sizeof(T));
   NAME(est_data).table = table;
   NAME(est_data).pcs = pcs;
   NAME(est_data).dst = dst;


### PR DESCRIPTION
I don't know if this is necessary but I read somewhere it need one extra unit during access.
