### PR TITLE
Fix condition with --disk option

### DIFF
--- a/src/tbgen.c
+++ b/src/tbgen.c
@@ -940,7 +940,7 @@ int main(int argc, char **argv)
 
   if ((save_to_disk && !symmetric && generate_wdl) || wide) {
     store_table(table_w, 'w');
-    if (wide && !symmetric)
+    if (!symmetric)
       store_table(table_b, 'b');
   }
 


### PR DESCRIPTION
Non-wide tables should fulfill the condition here unless it is symmetric.