### PR TITLE
Fix initialization of symtable in 16-bit code

### DIFF
--- a/src/compress_tmpl.c
+++ b/src/compress_tmpl.c
@@ -16,10 +16,10 @@ void NAME(compress_init_dtz)(struct dtz_map *map)
 
   num_vals = map->max_num;
 
-  if (sizeof(T) == 1) {
-    for (i = 0; i < num_vals; i++) {
-      symtable[i].pattern[0] = i;
-      symtable[i].len = 1;
+  for (i = 0; i < num_vals; i++) {
+    symtable[i].pattern[0] = i;
+    symtable[i].len = 1;
+    if (sizeof(T) == 1) {
       for (j = 0; j < 256; j++)
         symcode[i][j] = i;
     }


### PR DESCRIPTION
Only symcode[][] initialization should be skipped.