### PR TITLE
Reference: where it backfires with too many threads

### DIFF
--- a/src/compress.c
+++ b/src/compress.c
@@ -274,7 +274,7 @@ struct HuffCode *construct_pairs_wdl(uint8_t *restrict data, uint64_t size,
   }
 
   adjust_work_dontcares_wdl(work, work_adj);
-  run_threaded(remove_wdl_worker, work_adj, 0);
+  run_threaded2(remove_wdl_worker, work_adj, 0, 64);
 
   num_syms = 9;
 
@@ -304,7 +304,7 @@ struct HuffCode *construct_pairs_wdl(uint8_t *restrict data, uint64_t size,
     for (i = 0; i < num_syms; i++)
       for (j = 0; j < num_syms; j++)
         countfreq[t][i][j] = 0;
-  run_threaded(count_pairs_wdl, work, 0);
+  run_threaded2(count_pairs_wdl, work, 0, 64);
   for (t = 0; t < numthreads; t++)
     for (i = 0; i < num_syms; i++)
       for (j = 0; j < num_syms; j++)
@@ -539,7 +539,7 @@ lab:
         }
 
     adjust_work_replace_u8(work);
-    run_threaded(replace_pairs_u8, work, 0);
+    run_threaded2(replace_pairs_u8, work, 0, 64);
 
     for (t = 0; t < numthreads; t++)
       for (i = 0; i < num3; i++)

--- a/src/compress_tmpl.c
+++ b/src/compress_tmpl.c
@@ -307,7 +307,7 @@ static struct HuffCode *NAME(construct_pairs_dtz)(T *data, uint64_t size,
   }
 
   NAME(adjust_work_dontcares_dtz)(work, work_adj);
-  run_threaded(NAME(remove_dtz_worker), work_adj, 0);
+  run_threaded2(NAME(remove_dtz_worker), work_adj, 0, 64);
 
   // first round of freq counting, to fill in dont cares
   for (i = 0; i < num_syms; i++)
@@ -318,7 +318,7 @@ static struct HuffCode *NAME(construct_pairs_dtz)(T *data, uint64_t size,
     for (i = 0; i < num_syms; i++)
       for (j = 0; j < num_syms; j++)
         NAME(countfreq_dtz)[t][i][j] = 0;
-  run_threaded(NAME(count_pairs_dtz), work, 0);
+  run_threaded2(NAME(count_pairs_dtz), work, 0, 64);
   for (t = 0; t < numthreads; t++)
     for (i = 0; i < num_syms; i++)
       for (j = 0; j < num_syms; j++)
@@ -348,7 +348,7 @@ static struct HuffCode *NAME(construct_pairs_dtz)(T *data, uint64_t size,
       newtest[i][j] = 0;
 
   NAME(adjust_work_dontcares)(work, work_adj);
-  run_threaded(NAME(fill_dontcares), work_adj, 0);
+  run_threaded2(NAME(fill_dontcares), work_adj, 0, 64);
 
   for (i = 0; i < num_syms; i++)
     for (j = 0; j < num_syms; j++)
@@ -358,7 +358,7 @@ static struct HuffCode *NAME(construct_pairs_dtz)(T *data, uint64_t size,
     for (i = 0; i < num_syms; i++)
       for (j = 0; j < num_syms; j++)
         NAME(countfreq_dtz)[t][i][j] = 0;
-  run_threaded(NAME(count_pairs_dtz), work, 0);
+  run_threaded2(NAME(count_pairs_dtz), work, 0, 64);
   for (t = 0; t < numthreads; t++)
     for (i = 0; i < num_syms; i++)
       for (j = 0; j < num_syms; j++)
@@ -456,7 +456,7 @@ static struct HuffCode *NAME(construct_pairs_dtz)(T *data, uint64_t size,
         }
 
     NAME(adjust_work_replace)(work);
-    run_threaded(NAME(replace_pairs), work, 0);
+    run_threaded2(NAME(replace_pairs), work, 0, 64);
 
     for (t = 0; t < numthreads; t++)
       for (i = 0; i < num; i++)

--- a/src/reduce_tmpl.c
+++ b/src/reduce_tmpl.c
@@ -144,7 +144,7 @@ static void NAME(reconstruct_table)(T *table, char color, struct dtz_map *map)
 
   NAME(transform_v) = v;
   NAME(transform_tbl) = table;
-  run_threaded(NAME(transform_table), work_g, 0);
+  run_threaded2(NAME(transform_table), work_g, 0, 64);
 
   v[0] = 0;
   int red_cnt = 0;

--- a/src/rtbgen.c
+++ b/src/rtbgen.c
@@ -972,7 +972,7 @@ static void fix_closs_w(void)
   }
 
   printf("fixing cursed white losses.\n");
-  run_threaded(fix_closs_worker_w, work_g, 1);
+  run_threaded2(fix_closs_worker_w, work_g, 1, 64);
 }
 
 static void fix_closs_b(void)
@@ -999,5 +999,5 @@ static void fix_closs_b(void)
   }
 
   printf("fixing cursed black losses.\n");
-  run_threaded(fix_closs_worker_b, work_g, 1);
+  run_threaded2(fix_closs_worker_b, work_g, 1, 64);
 }

--- a/src/threads.c
+++ b/src/threads.c
@@ -22,6 +22,7 @@
 
 int numa = 0;
 int num_nodes[4] = { 1, 2, 4, 8 };
+int th_limit = 0;
 
 struct thread_data *thread_data;
 
@@ -272,13 +273,14 @@ THREAD_FUNC worker(void *arg)
     struct Queue *queue = &queues[numa_threading ? thread->node : 0];
     int total = queue->total;
     WorkerFunc func = worker_func;
-
-    while (1) {
-      w = __sync_fetch_and_add(&queue->counter, 1);
-      if (w >= total) break;
-      thread->begin = queue->work[w];
-      thread->end = queue->work[w + 1];
-      func(thread);
+    if(th_limit == 0 || t < th_limit - 1) {
+      while (1) {
+        w = __sync_fetch_and_add(&queue->counter, 1);
+        if (w >= total) break;
+        thread->begin = queue->work[w];
+        thread->end = queue->work[w + 1];
+        func(thread);
+      }
     }
 
 #ifndef __WIN32__
@@ -293,12 +295,15 @@ THREAD_FUNC worker(void *arg)
 
   return 0;
 }
-
 void run_threaded(WorkerFunc func, struct Work *work, int report_time)
+{
+  run_threaded2(func, work, report_time, 0);
+}
+void run_threaded2(WorkerFunc func, struct Work *work, int report_time, int limit)
 {
   int secs, usecs;
   struct timeval stop_time;
-
+  th_limit = limit;
   worker_func = func;
   if (!work->numa) {
     numa_threading = 0;

--- a/src/threads.c
+++ b/src/threads.c
@@ -273,7 +273,7 @@ THREAD_FUNC worker(void *arg)
     struct Queue *queue = &queues[numa_threading ? thread->node : 0];
     int total = queue->total;
     WorkerFunc func = worker_func;
-    if(numa || th_limit == 0 || t < th_limit - 1) {
+    if(th_limit == 0 || (!numa_threading && t < (th_limit - 1)) || (numa_threading && (t - (thread->node * numthreads / num_nodes[numa])) < (th_limit / num_nodes[numa]))) {
       while (1) {
         w = __sync_fetch_and_add(&queue->counter, 1);
         if (w >= total) break;

--- a/src/threads.c
+++ b/src/threads.c
@@ -273,7 +273,7 @@ THREAD_FUNC worker(void *arg)
     struct Queue *queue = &queues[numa_threading ? thread->node : 0];
     int total = queue->total;
     WorkerFunc func = worker_func;
-    if(th_limit == 0 || t < th_limit - 1) {
+    if(numa || th_limit == 0 || t < th_limit - 1) {
       while (1) {
         w = __sync_fetch_and_add(&queue->counter, 1);
         if (w >= total) break;

--- a/src/threads.h
+++ b/src/threads.h
@@ -56,6 +56,8 @@ struct Work {
 void init_threads(int pawns);
 void run_threaded(void (*func)(struct thread_data *), struct Work *work,
     int report_time);
+void run_threaded2(void (*func)(struct thread_data *), struct Work *work,
+    int report_time, int limit);
 void run_single(void (*func)(struct thread_data *), struct Work *work,
     int report_time);
 void fill_work(int n, uint64_t size, uint64_t mask, struct Work *w);


### PR DESCRIPTION
I did some performance measurements and these are verified that less threads run faster, without -d option.
