### PR TITLE
fix compiling errors

### DIFF
--- a/src/permute.c
+++ b/src/permute.c
@@ -37,7 +37,7 @@ extern uint64_t diagonal;
 extern int shift[];
 #endif
 
-char name[64];
+extern char name[64];
 
 struct TBEntry_piece entry_piece;
 struct TBEntry_pawn entry_pawn;
@@ -66,8 +66,8 @@ uint64_t compest[MAX_PERMS];
 
 int trylist[MAX_CANDS];
 
-int numpawns;
-int numpcs;
+extern int numpawns;
+extern int numpcs;
 
 static int pw[TBPIECES];
 int cmp[16];


### PR DESCRIPTION
when use `make all`,some error generates:
```
/usr/bin/ld: objsr/permute.o (symbol from plugin): in function `entry_piece':
(.text+0x0): multiple definition of `numpcs'; objsr/tbgen.o (symbol from plugin):(.text+0x0): first defined here
/usr/bin/ld: objsr/permute.o (symbol from plugin): in function `entry_piece':
(.text+0x0): multiple definition of `numpawns'; objsr/tbgen.o (symbol from plugin):(.text+0x0): first defined here
/usr/bin/ld: objsr/compress.o (symbol from plugin): in function `newpairs':
(.text+0x0): multiple definition of `name'; objsr/permute.o (symbol from plugin):(.text+0x0): first defined here
```
I tried add 3 `extern` label and the error disappeared.
Feel free to merge or close this PR.